### PR TITLE
Add `Item5e.displayCard` hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,19 @@ A hook event that fires after an Actor rolls a Skill Check
 
 ### Items
 
+#### Item5e.displayCard(item, chatMessage, [options])
+
+A hook event that fires after an Item Roll's chat message is created
+
+| Param                     | Type                                            | Description                                                                   |
+| ------------------------- | ----------------------------------------------- | ----------------------------------------------------------------------------- |
+| item                      | <code>Item5e</code>                             | The Item being rolled                                                         |
+| chatMessage               | <code>ChatMessage</code> \| <code>object</code> | The created ChatMessage or ChatMessageData depending on options.createMessage |
+| [options]                 | <code>object</code>                             |                                                                               |
+| [options.rollMode]        | <code>string</code>                             | The roll display mode with which to display (or not) the card                 |
+| [options.createMessage]   | <code>boolean</code>                            | Whether to automatically create a ChatMessage document (if true), or only return the prepared message data (if false)     |
+| [actor]   | <code>Actor5e</code> | The Actor that owns the item                             |
+
 #### Item5e.roll(item, chatMessage, [options])
 
 A hook event that fires after an Item is rolled
@@ -75,7 +88,8 @@ A hook event that fires after an Item is rolled
 | [options]                 | <code>object</code>                             |                                                                               |
 | [options.configureDialog] | <code>boolean</code>                            | Display a configuration dialog for the item roll, if applicable?              |
 | [options.rollMode]        | <code>string</code>                             | The roll display mode with which to display (or not) the card                 |
-| [options.createMessage]   | <code>boolean</code>                            | Whether to automatically create a chat message (if true) or simply return     |
+| [options.createMessage]   | <code>boolean</code>                            | Whether to automatically create a ChatMessage document (if true), or only return the prepared message data (if false)     |
+| [actor]   | <code>Actor5e</code> | The Actor that owns the item                             |
 
 #### Item5e.rollAttack(item, result, [options], [actor])
 

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "more-hooks-5e",
   "title": "More Hooks D&D5e",
   "description": "A library module which adds more Hooks for events in the 5e system.",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "author": "Andrew Krigline",
   "authors": [
     {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "more-hooks-5e",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A library module which adds more Hooks for events in the 5e system.",
   "license": "MIT",
   "repository": {

--- a/scripts/item/displayCard.js
+++ b/scripts/item/displayCard.js
@@ -16,7 +16,7 @@ async function displayCardPatch(wrapper, options, ...rest) {
 }
 
 /**
- * A hook event that fires after an Item is rolled
+ * A hook event that fires after an Item Roll's chat message is created
  * @param {Item5e} item       The Item being rolled
  * @param {ChatMessage|object} chatMessage       The created ChatMessage or ChatMessageData depending on options.createMessage
  * @param {object} [options]

--- a/scripts/item/displayCard.js
+++ b/scripts/item/displayCard.js
@@ -1,0 +1,27 @@
+import { MODULE_NAME } from "../const.js";
+
+export function patchDisplayCard() {
+  libWrapper.register(MODULE_NAME, "CONFIG.Item.documentClass.prototype.displayCard", displayCardPatch, "WRAPPER");
+}
+
+async function displayCardPatch(wrapper, options, ...rest) {
+  const chatMessage = await wrapper(options, ...rest);
+
+  const item = this;
+  const actor = this.actor;
+
+  Hooks.callAll('Item5e.displayCard', item, chatMessage, options, actor);
+
+  return chatMessage;
+}
+
+/**
+ * A hook event that fires after an Item is rolled
+ * @param {Item5e} item       The Item being rolled
+ * @param {ChatMessage|object} chatMessage       The created ChatMessage or ChatMessageData depending on options.createMessage
+ * @param {object} [options]
+ * @param {boolean} [options.rollMode]     The message visibility mode to apply to the created card
+ * @param {string} [options.createMessage]             Whether to automatically create a ChatMessage entity (if true), or only return the prepared message data (if false)
+ * @param {Actor5e} [actor]       The Actor that owns the item
+ */
+function displayCard() { }

--- a/scripts/item/roll.js
+++ b/scripts/item/roll.js
@@ -22,6 +22,7 @@ async function rollPatch(wrapper, options, ...rest) {
  * @param {object} [options]
  * @param {boolean} [options.configureDialog]     Display a configuration dialog for the item roll, if applicable?
  * @param {string} [options.rollMode]             The roll display mode with which to display (or not) the card
- * @param {boolean} [options.createMessage]       Whether to automatically create a chat message (if true) or simply return
+ * @param {boolean} [options.createMessage]       Whether to automatically create a ChatMessage document (if true), or only return the prepared message data (if false)
+ * @param {Actor5e} [actor]       The Actor that owns the item
  */
 function roll() { }  

--- a/setup.js
+++ b/setup.js
@@ -5,6 +5,7 @@ import { patchRollDeathSave } from './scripts/actor/rollDeathSave.js'
 import { patchRollSkill } from './scripts/actor/rollSkill.js'
 import { patchRollDamage } from './scripts/item/damageRoll.js'
 import { patchRoll } from './scripts/item/roll.js'
+import { patchDisplayCard } from './scripts/item/displayCard.js'
 import { patchRollAttack } from './scripts/item/rollAttack.js'
 import { patchRollFormula } from './scripts/item/rollFormula.js'
 import { patchRollRecharge } from './scripts/item/rollRecharge.js'
@@ -12,13 +13,14 @@ import { patchRollToolCheck } from './scripts/item/rollToolCheck.js'
 
 Hooks.on("setup", () => {
   console.log(`${MODULE_NAME} | Initializing ${MODULE_TITLE}`);
-  // actor sockets
+  // actor hooks
   patchRollAbilitySave();
   patchRollAbilityTest();
   patchRollDeathSave();
   patchRollSkill();
 
-  // item sockets
+  // item hooks
+  patchDisplayCard();
   patchRollDamage();
   patchRoll();
   patchRollAttack();


### PR DESCRIPTION
Adds a Hook to fire after `Item5e.displayCard`. This allows modules to inject flags or mutate the contents of the card created by an item's roll flow.