### PR TITLE
fix: fix false hook calls when the workflow was actually aborted

### DIFF
--- a/scripts/actor/rollAbilitySave.js
+++ b/scripts/actor/rollAbilitySave.js
@@ -7,6 +7,8 @@ export function patchRollAbilitySave() {
 async function rollAbilitySavePatch(wrapper, abilityId, options, ...rest) {
   const result = await wrapper(abilityId, options, ...rest);
 
+  if (!result) return result;
+
   const actor = this;
 
   Hooks.callAll('Actor5e.rollAbilitySave', actor, result, abilityId, options);

--- a/scripts/actor/rollAbilityTest.js
+++ b/scripts/actor/rollAbilityTest.js
@@ -8,6 +8,8 @@ export function patchRollAbilityTest() {
 async function rollAbilityTestPatch(wrapper, abilityId, options, ...rest) {
   const result = await wrapper(abilityId, options, ...rest);
 
+  if (!result) return result;
+
   const actor = this;
 
   Hooks.callAll('Actor5e.rollAbilityTest', actor, result, abilityId, options);

--- a/scripts/actor/rollDeathSave.js
+++ b/scripts/actor/rollDeathSave.js
@@ -7,6 +7,8 @@ export function patchRollDeathSave() {
 async function rollDeathSavePatch(wrapper, options, ...rest) {
   const result = await wrapper(options, ...rest);
 
+  if (!result) return result;
+
   const actor = this;
 
   Hooks.callAll('Actor5e.rollDeathSave', actor, result, options);

--- a/scripts/actor/rollSkill.js
+++ b/scripts/actor/rollSkill.js
@@ -7,6 +7,8 @@ export function patchRollSkill() {
 async function rollSkillPatch(wrapper, skillId, options, ...rest) {
   const result = await wrapper(skillId, options, ...rest);
 
+  if (!result) return result;
+
   const actor = this;
 
   Hooks.callAll('Actor5e.rollSkill', actor, result, skillId, options);

--- a/scripts/item/damageRoll.js
+++ b/scripts/item/damageRoll.js
@@ -7,6 +7,8 @@ export function patchRollDamage() {
 async function rollDamagePatch(wrapper, config, ...rest) {
   const result = await wrapper(config, ...rest);
 
+  if (!result) return result;
+
   const item = this;
   const actor = this.actor;
 

--- a/scripts/item/roll.js
+++ b/scripts/item/roll.js
@@ -7,6 +7,8 @@ export function patchRoll() {
 async function rollPatch(wrapper, options, ...rest) {
   const chatMessage = await wrapper(options, ...rest);
 
+  if (!chatMessage) return chatMessage;
+
   const item = this;
   const actor = this.actor;
 

--- a/scripts/item/rollAttack.js
+++ b/scripts/item/rollAttack.js
@@ -7,6 +7,8 @@ export function patchRollAttack() {
 async function rollAttackPatch(wrapper, options, ...rest) {
   const result = await wrapper(options, ...rest);
 
+  if (!result) return result;
+
   const item = this;
   const actor = this.actor;
 

--- a/scripts/item/rollFormula.js
+++ b/scripts/item/rollFormula.js
@@ -7,6 +7,8 @@ export function patchRollFormula() {
 async function rollFormulaPatch(wrapper, config, ...rest) {
   const result = await wrapper(config, ...rest);
 
+  if (!result) return result;
+
   const item = this;
   const actor = this.actor;
 

--- a/scripts/item/rollRecharge.js
+++ b/scripts/item/rollRecharge.js
@@ -6,6 +6,8 @@ export function patchRollRecharge() {
 async function rollRechargePatch(wrapped, ...args) {
   const result = await wrapped(...args);
 
+  if (!result) return result;
+
   const item = this;
   const actor = this.actor;
 

--- a/scripts/item/rollToolCheck.js
+++ b/scripts/item/rollToolCheck.js
@@ -6,6 +6,8 @@ export function patchRollToolCheck() {
 async function rollToolCheckPatch(wrapper, options, ...rest) {
   const result = await wrapper(options, ...rest);
 
+  if (!result) return result;
+
   const item = this;
   const actor = this.actor;
 


### PR DESCRIPTION
Almost all of the rolling workflows have the ability to be canceled in the dialog that pops up. Even when canceled the Hook would still fire though.