### PR TITLE
feat: add applyDamage hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 api.md
 node_modules/
+more-hooks-5e.lock

--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ Its goal is to eventually contribute these hooks directly to the core 5e system 
 
 ### Actors
 
+#### Actor5e.applyDamage(actor, totalDamageTaken, prevHp, newHp)
+
+A hook event that fires after an Actor takes damage. Note this only fires when the `applyDamage` method is called, not when the actor's HP is updated manually.
+
+| Param     | Type                 | Description                                              |
+| --------- | -------------------- | -------------------------------------------------------- |
+| actor     | <code>Actor5e</code> | The Actor that took the damage                   |
+| totalDamageTaken    | <code>number</code> | The total amount of damage the actor took                           |
+| prevHp | <code>object</code>  | The hp attribute for the actor before taking damage.                              |
+| newHp   | <code>object</code>  | The hp attribute of the Actor after taking damage. |
+
 #### Actor5e.rollAbilitySave(actor, result, abilityId, options)
 
 A hook event that fires after an Actor rolls a Ability Save

--- a/scripts/actor/applyDamage.js
+++ b/scripts/actor/applyDamage.js
@@ -25,7 +25,7 @@ async function applyDamagePatch(wrapper, amount, multiplier, ...rest) {
 }
 
 /**
- * A hook event that fires after an Actor rolls a Skill Check
+ * A hook event that fires after an Actor takes damage. Note this only fires when the `applyDamage` method is called, not when the actor's HP is updated manually.
  * @param {Actor5e} actor       The Actor that took the damage
  * @param {number} totalDamageTaken           The total amount of damage the actor took
  * @param {object} prevHp           The hp attribute of the Actor before taking damage

--- a/scripts/actor/damageTaken.js
+++ b/scripts/actor/damageTaken.js
@@ -1,0 +1,35 @@
+import { MODULE_NAME } from "../const.js";
+
+export function patchApplyDamage() {
+  libWrapper.register(MODULE_NAME, 'CONFIG.Actor.documentClass.prototype.applyDamage', applyDamagePatch, "WRAPPER");
+}
+
+async function applyDamagePatch(wrapper, amount, multiplier, ...rest) {
+  // this is mutated after wrapper is done
+  const prevHp = this.data.data.attributes?.hp;
+
+  const result = await wrapper(amount, multiplier, ...rest);
+
+  // abort if the wrapper didn't apply damage
+  if (!result) return result;
+
+  const totalDamageTaken = Math.floor(parseInt(amount ?? 0) * (multiplier ?? 1)) * -1;
+
+  const newHp = this.data.data.attributes?.hp;
+
+  const actor = this;
+
+  Hooks.callAll('Actor5e.applyDamage', actor, totalDamageTaken, prevHp, newHp);
+
+  return result;
+}
+
+/**
+ * A hook event that fires after an Actor rolls a Skill Check
+ * @param {Actor5e} actor       The Actor that took the damage
+ * @param {number} totalDamageTaken           The total amount of damage the actor took
+ * @param {object} prevHp           The hp attribute of the Actor before taking damage
+ * @param {object} newHp           The hp attribute of the Actor after taking damage
+ * 
+ */
+function applyDamage() { }

--- a/setup.js
+++ b/setup.js
@@ -1,19 +1,21 @@
-import { MODULE_TITLE, MODULE_NAME } from "./scripts/const.js";
-import { patchRollAbilitySave } from './scripts/actor/rollAbilitySave.js'
-import { patchRollAbilityTest } from './scripts/actor/rollAbilityTest.js'
-import { patchRollDeathSave } from './scripts/actor/rollDeathSave.js'
-import { patchRollSkill } from './scripts/actor/rollSkill.js'
-import { patchRollDamage } from './scripts/item/damageRoll.js'
-import { patchRoll } from './scripts/item/roll.js'
-import { patchDisplayCard } from './scripts/item/displayCard.js'
-import { patchRollAttack } from './scripts/item/rollAttack.js'
-import { patchRollFormula } from './scripts/item/rollFormula.js'
-import { patchRollRecharge } from './scripts/item/rollRecharge.js'
-import { patchRollToolCheck } from './scripts/item/rollToolCheck.js'
+import { patchApplyDamage } from "./scripts/actor/damageTaken.js";
+import { patchRollAbilitySave } from './scripts/actor/rollAbilitySave.js';
+import { patchRollAbilityTest } from './scripts/actor/rollAbilityTest.js';
+import { patchRollDeathSave } from './scripts/actor/rollDeathSave.js';
+import { patchRollSkill } from './scripts/actor/rollSkill.js';
+import { MODULE_NAME, MODULE_TITLE } from "./scripts/const.js";
+import { patchRollDamage } from './scripts/item/damageRoll.js';
+import { patchDisplayCard } from './scripts/item/displayCard.js';
+import { patchRoll } from './scripts/item/roll.js';
+import { patchRollAttack } from './scripts/item/rollAttack.js';
+import { patchRollFormula } from './scripts/item/rollFormula.js';
+import { patchRollRecharge } from './scripts/item/rollRecharge.js';
+import { patchRollToolCheck } from './scripts/item/rollToolCheck.js';
 
 Hooks.on("setup", () => {
   console.log(`${MODULE_NAME} | Initializing ${MODULE_TITLE}`);
   // actor hooks
+  patchApplyDamage();
   patchRollAbilitySave();
   patchRollAbilityTest();
   patchRollDeathSave();

--- a/setup.js
+++ b/setup.js
@@ -1,4 +1,4 @@
-import { patchApplyDamage } from "./scripts/actor/damageTaken.js";
+import { patchApplyDamage } from "./scripts/actor/applyDamage.js";
 import { patchRollAbilitySave } from './scripts/actor/rollAbilitySave.js';
 import { patchRollAbilityTest } from './scripts/actor/rollAbilityTest.js';
 import { patchRollDeathSave } from './scripts/actor/rollDeathSave.js';


### PR DESCRIPTION
Adds the following hook:

#### Actor5e.applyDamage(actor, totalDamageTaken, prevHp, newHp)

A hook event that fires after an Actor takes damage. Note this only fires when the `applyDamage` method is called, not when the actor's HP is updated manually.

| Param     | Type                 | Description                                              |
| --------- | -------------------- | -------------------------------------------------------- |
| actor     | <code>Actor5e</code> | The Actor that took the damage                   |
| totalDamageTaken    | <code>number</code> | The total amount of damage the actor took                           |
| prevHp | <code>object</code>  | The hp attribute for the actor before taking damage.                              |
| newHp   | <code>object</code>  | The hp attribute of the Actor after taking damage. |